### PR TITLE
Replace the sklearn Lasso instantiated in sklearn LassoCV by ours

### DIFF
--- a/celer/dropin_sklearn.py
+++ b/celer/dropin_sklearn.py
@@ -1,8 +1,8 @@
 # flake8: noqa F401
 import inspect
 import numpy as np
-from scipy import sparse
 
+from scipy import sparse
 from abc import ABCMeta, abstractmethod
 from sklearn.base import RegressorMixin
 from sklearn.linear_model.base import LinearModel
@@ -16,10 +16,17 @@ from sklearn.linear_model import (Lasso as Lasso_sklearn,
                                   LassoCV as _LassoCV)
 from sklearn.linear_model.coordinate_descent import (LinearModelCV as
                                                      _LinearModelCV)
-from sklearn.linear_model.coordinate_descent import _alpha_grid, _path_residuals
-
+from sklearn.linear_model.coordinate_descent import (_alpha_grid,
+                                                     _path_residuals)
 
 from .homotopy import celer_path
+
+# Hack because `model = Lasso()` is hardcoded in _LinearModelCV definition
+lines = inspect.getsource(_LinearModelCV)
+exec(lines)  # when this is executed Lasso is our class, not sklearn's
+lines = inspect.getsource(_LassoCV)
+lines = lines.replace('LassoCV', 'LassoCV_sklearn')
+exec(lines)
 
 
 class Lasso(Lasso_sklearn):
@@ -123,13 +130,6 @@ class Lasso(Lasso_sklearn):
             gap_freq=self.gap_freq, max_epochs=self.max_epochs, p0=self.p0,
             verbose=self.verbose, tol=self.tol, prune=self.prune)
         return (alphas, coefs, dual_gaps, [1])
-
-# Hack because model = Lasso() is hardcoded in _LinearModelCV definition
-lines = inspect.getsource(_LinearModelCV)
-exec(lines)  # when this is executed Lasso is our class, not sklearn's
-lines = inspect.getsource(_LassoCV)
-lines = lines.replace('LassoCV', 'LassoCV_sklearn')
-exec(lines)
 
 
 class LassoCV(LassoCV_sklearn):

--- a/celer/dropin_sklearn.py
+++ b/celer/dropin_sklearn.py
@@ -1,7 +1,30 @@
+import inspect
+import numpy as np
+from scipy import sparse
+
+from abc import ABCMeta, abstractmethod
+from sklearn.base import RegressorMixin
+from sklearn.linear_model.base import LinearModel
+from sklearn.utils import check_array
+from sklearn.externals import six
+from sklearn.utils.validation import column_or_1d
+from sklearn.model_selection import check_cv
+from sklearn.externals.joblib import Parallel, delayed
+from sklearn.linear_model import ElasticNetCV, lasso_path
 from sklearn.linear_model import (Lasso as Lasso_sklearn,
-                                  LassoCV as LassoCV_sklearn)
+                                  LassoCV as _LassoCV)
+from sklearn.linear_model.coordinate_descent import (LinearModelCV as
+                                                     _LinearModelCV)
+from sklearn.linear_model.coordinate_descent import _alpha_grid, _path_residuals
+
 
 from .homotopy import celer_path
+
+lines = inspect.getsource(_LinearModelCV)
+exec(lines)
+lines = inspect.getsource(_LassoCV)
+lines = lines.replace('LassoCV', 'LassoCV_sklearn')
+exec(lines)
 
 
 class Lasso(Lasso_sklearn):

--- a/celer/dropin_sklearn.py
+++ b/celer/dropin_sklearn.py
@@ -1,3 +1,4 @@
+# flake8: noqa F401
 import inspect
 import numpy as np
 from scipy import sparse

--- a/celer/dropin_sklearn.py
+++ b/celer/dropin_sklearn.py
@@ -21,12 +21,6 @@ from sklearn.linear_model.coordinate_descent import _alpha_grid, _path_residuals
 
 from .homotopy import celer_path
 
-lines = inspect.getsource(_LinearModelCV)
-exec(lines)
-lines = inspect.getsource(_LassoCV)
-lines = lines.replace('LassoCV', 'LassoCV_sklearn')
-exec(lines)
-
 
 class Lasso(Lasso_sklearn):
     """Lasso scikit-learn estimator based on Celer solver
@@ -129,6 +123,13 @@ class Lasso(Lasso_sklearn):
             gap_freq=self.gap_freq, max_epochs=self.max_epochs, p0=self.p0,
             verbose=self.verbose, tol=self.tol, prune=self.prune)
         return (alphas, coefs, dual_gaps, [1])
+
+# Hack because model = Lasso() is hardcoded in _LinearModelCV definition
+lines = inspect.getsource(_LinearModelCV)
+exec(lines)  # when this is executed Lasso is our class, not sklearn's
+lines = inspect.getsource(_LassoCV)
+lines = lines.replace('LassoCV', 'LassoCV_sklearn')
+exec(lines)
 
 
 class LassoCV(LassoCV_sklearn):


### PR DESCRIPTION
@agramfort this is a workaround, WDYT?

the other solution I see is to copy paster the LinearModelCV.fit() method into our LassoCV and to change the line `model = Lasso()` ([here](https://github.com/scikit-learn/scikit-learn/blob/a24c8b46/sklearn/linear_model/coordinate_descent.py#L1090))