### PR TITLE
Fused types for cython solvers

### DIFF
--- a/celer/dense.pyx
+++ b/celer/dense.pyx
@@ -1,38 +1,39 @@
+cimport cython
 import time
-
 import numpy as np
 cimport numpy as np
 
-from scipy.linalg.cython_blas cimport ddot, dasum, daxpy, dnrm2, dcopy, dscal
-from scipy.linalg.cython_lapack cimport dposv
+# from scipy.linalg.cython_blas cimport fused_dot, fused_asum, fused_axpy, fused_nrm2, fused_copy, fused_scal
+from cython cimport floating
 
 from libc.math cimport fabs, sqrt, ceil
-cimport cython
 from utils cimport fmax, primal_value, dual_value, ST
-
+from utils cimport (fused_dot, fused_asum, fused_axpy, fused_nrm2,
+                    fused_copy, fused_scal, fused_posv)
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef double compute_dual_scaling_dense(int n_samples, int n_features,
-                                       double[:] theta, double[::1, :] X,
-                                       int ws_size, int * C) nogil:
+cdef floating compute_dual_scaling_dense(int n_samples, int n_features,
+                                         floating[:] theta, floating[::1, :] X,
+                                         int ws_size, int * C) nogil:
     """compute norm(X.T.dot(theta), ord=inf),
     with X restricted to features (columns) with indices in array C.
     if ws_size == n_features, C=np.arange(n_features is used)"""
-    cdef double Xj_theta
-    cdef double scal = 1.
+    cdef floating Xj_theta
+    cdef floating scal = 1.
     cdef int j
     cdef int Cj
     cdef int inc = 1
     if ws_size == n_features: # scaling wrt all features
         for j in range(n_features):
-            Xj_theta = fabs(ddot(&n_samples, &theta[0], &inc, &X[0, j], &inc))
+            Xj_theta = fused_dot(&n_samples, &theta[0], &inc, &X[0, j], &inc)
+            Xj_theta = fabs(Xj_theta)
             scal = max(scal, Xj_theta)
     else: # scaling wrt features in C only
         for j in range(ws_size):
             Cj = C[j]
-            Xj_theta = fabs(ddot(&n_samples, &theta[0], &inc, &X[0, Cj], &inc))
+            Xj_theta = fabs(fused_dot(&n_samples, &theta[0], &inc, &X[0, Cj], &inc))
             scal = max(scal, Xj_theta)
     return scal
 
@@ -40,25 +41,25 @@ cdef double compute_dual_scaling_dense(int n_samples, int n_features,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef void set_feature_prios_dense(int n_samples, int n_features, double[:] theta,
-                                  double[::1, :] X,  double * norms_X_col,
-                                  double * prios) nogil:
+cdef void set_feature_prios_dense(int n_samples, int n_features, floating[:] theta,
+                                  floating[::1, :] X,  floating * norms_X_col,
+                                  floating * prios) nogil:
     cdef int j
     cdef int inc = 1
-    cdef double Xj_theta
+    cdef floating Xj_theta
 
     for j in range(n_features):
-        Xj_theta = ddot(&n_samples, &theta[0], &inc, &X[0, j], &inc)
+        Xj_theta = fused_dot(&n_samples, &theta[0], &inc, &X[0, j], &inc)
         prios[j] = fabs(fabs(Xj_theta) - 1.) / norms_X_col[j]
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-def celer_dense(double[::1, :] X,
-                double[:] y,
-                double alpha,
-                double[:] beta_init,
+def celer_dense(floating[::1, :] X,
+                floating[:] y,
+                floating alpha,
+                floating[:] beta_init,
                 int max_iter,
                 int max_epochs,
                 int gap_freq=10,
@@ -80,29 +81,29 @@ def celer_dense(double[::1, :] X,
 
 
     cdef int n_samples = y.shape[0]
-    cdef double[:] beta = np.empty(n_features)
+    cdef floating[:] beta = np.empty(n_features)
     cdef int j  # features
     cdef int i  # samples
     cdef int ii
     cdef int t  # outer loop
     cdef int inc = 1
-    cdef double tmp
+    cdef floating tmp
     cdef int ws_size = 0
-    cdef double p_obj
-    cdef double d_obj
-    cdef double highest_d_obj
-    cdef double scal
-    cdef double gap
-    cdef double[:] prios = np.empty(n_features)
-    cdef double[:] norms_X_col = np.empty(n_features)
+    cdef floating p_obj
+    cdef floating d_obj
+    cdef floating highest_d_obj
+    cdef floating scal
+    cdef floating gap
+    cdef floating[:] prios = np.empty(n_features)
+    cdef floating[:] norms_X_col = np.empty(n_features)
 
     # compute norms_X_col
     for j in range(n_features):
-        norms_X_col[j] = dnrm2(&n_samples, &X[0, j], &inc)
+        norms_X_col[j] = fused_nrm2(&n_samples, &X[0, j], &inc)
 
-    cdef double norm_y2 = dnrm2(&n_samples, &y[0], &inc) ** 2
-    cdef double[:] invnorm_Xcols_2 = np.empty(n_features)
-    cdef double[:] alpha_invnorm_Xcols_2 = np.empty(n_features)
+    cdef floating norm_y2 = fused_nrm2(&n_samples, &y[0], &inc) ** 2
+    cdef floating[:] invnorm_Xcols_2 = np.empty(n_features)
+    cdef floating[:] alpha_invnorm_Xcols_2 = np.empty(n_features)
 
     for j in range(n_features):
         beta[j] = beta_init[j]
@@ -110,40 +111,40 @@ def celer_dense(double[::1, :] X,
         alpha_invnorm_Xcols_2[j] = alpha * invnorm_Xcols_2[j]
 
     cdef double[:] times = np.zeros(max_iter)
-    cdef double[:] gaps = np.zeros(max_iter)
-    cdef double[:] epochs = np.zeros(max_iter)
-    cdef double[:] ws_sizes = np.zeros(max_iter)
+    cdef floating[:] gaps = np.zeros(max_iter)
+    cdef floating[:] epochs = np.zeros(max_iter)
+    cdef floating[:] ws_sizes = np.zeros(max_iter)
 
-    cdef double[:] R = np.zeros(n_samples)
-    cdef double[:] theta = np.zeros(n_samples)
-    cdef double[:] theta_inner = np.zeros(n_samples)  # passed to inner solver
+    cdef floating[:] R = np.zeros(n_samples)
+    cdef floating[:] theta = np.zeros(n_samples)
+    cdef floating[:] theta_inner = np.zeros(n_samples)  # passed to inner solver
     # and potentially used for screening if it gives a better d_obj
-    cdef double d_obj_from_inner = 0
+    cdef floating d_obj_from_inner = 0
 
     cdef int[:] dummy_C = np.zeros(1, dtype=np.int32) # initialize with dummy value
     cdef int[:] all_features = np.arange(n_features, dtype=np.int32)
 
     for t in range(max_iter):
         # R = y - np.dot(X, beta)
-        dcopy(&n_samples, &y[0], &inc, &R[0], &inc)
+        fused_copy(&n_samples, &y[0], &inc, &R[0], &inc)
         for j in range(n_features):
             if beta[j] == 0.:
                 continue
             else:
                 tmp = - beta[j]
-                daxpy(&n_samples, &tmp, &X[0, j], &inc, &R[0], &inc)
+                fused_axpy(&n_samples, &tmp, &X[0, j], &inc, &R[0], &inc)
 
         # theta = R / (n_samples * alpha)
-        dcopy(&n_samples, &R[0], &inc, &theta[0], &inc)
+        fused_copy(&n_samples, &R[0], &inc, &theta[0], &inc)
         tmp = 1. / (n_samples * alpha)
-        dscal(&n_samples, &tmp, &theta[0], &inc)
+        fused_scal(&n_samples, &tmp, &theta[0], &inc)
 
         scal = compute_dual_scaling_dense(n_samples, n_features, theta, X,
             n_features, &dummy_C[0])
 
         if scal > 1.:
             tmp = 1. / scal
-            dscal(&n_samples, &tmp, &theta[0], &inc)
+            fused_scal(&n_samples, &tmp, &theta[0], &inc)
 
         d_obj = dual_value(n_samples, alpha, norm_y2, &theta[0],
                            &y[0])
@@ -155,14 +156,14 @@ def celer_dense(double[::1, :] X,
 
             if scal > 1.:
                 tmp = 1. / scal
-                dscal(&n_samples, &tmp, &theta_inner[0], &inc)
+                fused_scal(&n_samples, &tmp, &theta_inner[0], &inc)
 
             d_obj_from_inner = dual_value(n_samples, alpha, norm_y2,
                                           &theta_inner[0], &y[0])
 
         if d_obj_from_inner > d_obj:
             d_obj = d_obj_from_inner
-            dcopy(&n_samples, &theta_inner[0], &inc, &theta[0], &inc)
+            fused_copy(&n_samples, &theta_inner[0], &inc, &theta[0], &inc)
 
         if t == 0 or d_obj > highest_d_obj:
             highest_d_obj = d_obj
@@ -249,17 +250,17 @@ def celer_dense(double[::1, :] X,
 @cython.wraparound(False)
 @cython.cdivision(True)
 cpdef int inner_solver_dense(int n_samples, int n_features, int ws_size,
-                   double[::1, :] X,
-                   double[:] y,
-                   double alpha,
-                   double[:] beta,
-                   double[:] R,
+                   floating[::1, :] X,
+                   floating[:] y,
+                   floating alpha,
+                   floating[:] beta,
+                   floating[:] R,
                    int[:] C,
-                   double[:] theta,
-                   double[:] invnorm_Xcols_2,
-                   double[:] alpha_invnorm_Xcols_2,
-                   double norm_y2,
-                   double eps,
+                   floating[:] theta,
+                   floating[:] invnorm_Xcols_2,
+                   floating[:] alpha_invnorm_Xcols_2,
+                   floating norm_y2,
+                   floating eps,
                    int max_epochs,
                    int gap_freq,
                    int verbose=0,
@@ -274,34 +275,34 @@ cpdef int inner_solver_dense(int n_samples, int n_features, int ws_size,
     cdef int epoch
     cdef int start
     cdef int stop
-    cdef double old_beta_j
-    cdef double beta_Cj
+    cdef floating old_beta_j
+    cdef floating beta_Cj
     cdef int inc = 1
     # gap related:
-    cdef double gap
-    cdef double[:] gaps = np.zeros(max_epochs // gap_freq)
+    cdef floating gap
+    cdef floating[:] gaps = np.zeros(max_epochs // gap_freq)
 
-    cdef double[:] thetaccel = np.empty(n_samples)
-    cdef double dual_scale
-    cdef double d_obj
-    cdef double highest_d_obj = 0. # d_obj is always >=0 so this gets replaced
+    cdef floating[:] thetaccel = np.empty(n_samples)
+    cdef floating dual_scale
+    cdef floating d_obj
+    cdef floating highest_d_obj = 0. # d_obj is always >=0 so this gets replaced
     # at first d_obj computation. highest_d_obj corresponds to theta = 0.
-    cdef double tmp
+    cdef floating tmp
     # acceleration variables:
-    cdef double[:, :] last_K_res = np.empty([K, n_samples])
-    cdef double[:, :] U = np.empty([K - 1, n_samples])
-    cdef double[:, :] UtU = np.empty([K - 1, K - 1])
-    cdef double[:] onesK = np.ones(K - 1)
-    cdef double dual_scale_accel
-    cdef double d_obj_accel
+    cdef floating[:, :] last_K_res = np.empty([K, n_samples])
+    cdef floating[:, :] U = np.empty([K - 1, n_samples])
+    cdef floating[:, :] UtU = np.empty([K - 1, K - 1])
+    cdef floating[:] onesK = np.ones(K - 1, dtype=y.dtype)
+    cdef floating dual_scale_accel
+    cdef floating d_obj_accel
 
     # solving linear system in cython
     # doc at https://software.intel.com/en-us/node/468894
     cdef char char_U = 'U'
     cdef int Kminus1 = K - 1
     cdef int one = 1
-    cdef double sum_z
-    cdef int info_dposv
+    cdef floating sum_z
+    cdef int info_posv
 
     for i in range(n_samples):
         R[i] = y[i]
@@ -311,54 +312,54 @@ cpdef int inner_solver_dense(int n_samples, int n_features, int ws_size,
             continue
         else:
             tmp = - beta_Cj
-            daxpy(&n_samples, &tmp, &X[0, C[j]], &inc, &R[0], &inc)
+            fused_axpy(&n_samples, &tmp, &X[0, C[j]], &inc, &R[0], &inc)
 
     for epoch in range(max_epochs):
         if epoch % gap_freq == 1:
             # theta = R / (alpha * n_samples)
-            dcopy(&n_samples, &R[0], &inc, &theta[0], &inc)
+            fused_copy(&n_samples, &R[0], &inc, &theta[0], &inc)
             tmp = 1. / (alpha * n_samples)
-            dscal(&n_samples, &tmp, &theta[0], &inc)
+            fused_scal(&n_samples, &tmp, &theta[0], &inc)
 
             dual_scale = compute_dual_scaling_dense(
                 n_samples, n_features, theta, X, ws_size, &C[0])
 
             if dual_scale > 1.:
                 tmp = 1 / dual_scale
-                dscal(&n_samples, &tmp, &theta[0], &inc)
+                fused_scal(&n_samples, &tmp, &theta[0], &inc)
 
             d_obj = dual_value(n_samples, alpha, norm_y2, &theta[0], &y[0])
 
             if use_accel: # also compute accelerated dual_point
                 if epoch // gap_freq < K:
                     # last_K_res[it // f_gap] = R:
-                    dcopy(&n_samples, &R[0], &inc,
+                    fused_copy(&n_samples, &R[0], &inc,
                           &last_K_res[epoch // gap_freq, 0], &inc)
                 else:
                     for k in range(K - 1):
-                        dcopy(&n_samples, &last_K_res[k + 1, 0], &inc,
+                        fused_copy(&n_samples, &last_K_res[k + 1, 0], &inc,
                               &last_K_res[k, 0], &inc)
-                    dcopy(&n_samples, &R[0], &inc, &last_K_res[K - 1, 0], &inc)
+                    fused_copy(&n_samples, &R[0], &inc, &last_K_res[K - 1, 0], &inc)
                     for k in range(K - 1):
                         for i in range(n_samples):
                             U[k, i] = last_K_res[k + 1, i] - last_K_res[k, i]
 
                     for k in range(K - 1):
                         for jj in range(k, K - 1):
-                            UtU[k, jj] = ddot(&n_samples, &U[k, 0], &inc,
+                            UtU[k, jj] = fused_dot(&n_samples, &U[k, 0], &inc,
                                               &U[jj, 0], &inc)
                             UtU[jj, k] = UtU[k, jj]
 
                     # refill onesK with ones because it has been overwritten
-                    # by dposv
+                    # by *posv
                     for k in range(K - 1):
-                        onesK[k] = 1
+                        onesK[k] = 1.
 
-                    dposv(&char_U, &Kminus1, &one, &UtU[0, 0], &Kminus1,
-                           &onesK[0], &Kminus1, &info_dposv)
+                    fused_posv(&char_U, &Kminus1, &one, &UtU[0, 0], &Kminus1,
+                               &onesK[0], &Kminus1, &info_posv)
 
                     # onesK now holds the solution in x to UtU dot x = onesK
-                    if info_dposv != 0:
+                    if info_posv != 0:
                         if verbose:
                             print("linear system solving failed")
                         # don't use accel for this iteration
@@ -379,7 +380,7 @@ cpdef int inner_solver_dense(int n_samples, int n_features, int ws_size,
                             thetaccel[i] += onesK[k] * last_K_res[k, i]
 
                     tmp = 1. / (alpha * n_samples)
-                    dscal(&n_samples, &tmp, &thetaccel[0], &inc)
+                    fused_scal(&n_samples, &tmp, &thetaccel[0], &inc)
 
                     dual_scale_accel = compute_dual_scaling_dense(
                         n_samples, n_features, thetaccel, X, ws_size,
@@ -387,7 +388,7 @@ cpdef int inner_solver_dense(int n_samples, int n_features, int ws_size,
 
                     if dual_scale_accel > 1.:
                         tmp = 1. / dual_scale_accel
-                        dscal(&n_samples, &tmp, &thetaccel[0], &inc)
+                        fused_scal(&n_samples, &tmp, &thetaccel[0], &inc)
                     # d_obj_accel = 0.
                     # for i in range(n_samples):
                     #     d_obj_accel -= (y[i] / alpha - thetaccel[i] / dual_scale_accel) ** 2
@@ -401,7 +402,7 @@ cpdef int inner_solver_dense(int n_samples, int n_features, int ws_size,
                         d_obj = d_obj_accel
                         # theta = theta_accel (theta is defined as
                         # theta_inner in outer loop)
-                        dcopy(&n_samples, &thetaccel[0], &inc, &theta[0], &inc)
+                        fused_copy(&n_samples, &thetaccel[0], &inc, &theta[0], &inc)
 
             if d_obj > highest_d_obj:
                 highest_d_obj = d_obj
@@ -427,7 +428,7 @@ cpdef int inner_solver_dense(int n_samples, int n_features, int ws_size,
             # update feature k in place, cyclically
             j = C[k]
             old_beta_j = beta[j]
-            beta[j] += ddot(&n_samples, &X[0, j], &inc, &R[0], &inc) * invnorm_Xcols_2[j]
+            beta[j] += fused_dot(&n_samples, &X[0, j], &inc, &R[0], &inc) * invnorm_Xcols_2[j]
             # perform ST in place:
             beta[j] = ST(alpha_invnorm_Xcols_2[j] * n_samples, beta[j])
             tmp = beta[j] - old_beta_j
@@ -435,7 +436,7 @@ cpdef int inner_solver_dense(int n_samples, int n_features, int ws_size,
             # R -= (beta_j - old_beta_j) * X[:, j]
             if tmp != 0.:
                 tmp = -tmp
-                daxpy(&n_samples, &tmp, &X[0, j], &inc, &R[0], &inc)
+                fused_axpy(&n_samples, &tmp, &X[0, j], &inc, &R[0], &inc)
     else:
         print("!!! Inner solver did not converge at epoch %d, gap: %.2e > %.2e" % \
             (epoch, gap, eps))

--- a/celer/homotopy.py
+++ b/celer/homotopy.py
@@ -6,6 +6,8 @@
 import time
 import numpy as np
 
+from sklearn.utils import check_array
+
 from .wrapper import celer
 
 
@@ -79,6 +81,12 @@ def celer_path(X, y, eps=1e-3, n_alphas=100, alphas=None, max_iter=20,
         The dual variables along the path.
         (Is returned only when ``return_thetas`` is set to True).
     """
+
+    X = check_array(X, 'csc', dtype=[np.float64, np.float32],
+                    order='F', copy=False)
+    y = check_array(y, 'csc', dtype=X.dtype.type, order='F', copy=False,
+                    ensure_2d=False)
+
     n_samples, n_features = X.shape
     if alphas is None:
         alpha_max = np.max(np.abs(X.T.dot(y))) / n_samples

--- a/celer/homotopy.py
+++ b/celer/homotopy.py
@@ -82,14 +82,15 @@ def celer_path(X, y, eps=1e-3, n_alphas=100, alphas=None, max_iter=20,
     n_samples, n_features = X.shape
     if alphas is None:
         alpha_max = np.max(np.abs(X.T.dot(y))) / n_samples
-        alphas = alpha_max * np.logspace(0, np.log10(eps), n_alphas)
+        alphas = alpha_max * np.logspace(0, np.log10(eps), n_alphas,
+                                         dtype=X.dtype)
     else:
         alphas = np.sort(alphas)[::-1]
 
     n_alphas = len(alphas)
 
-    coefs = np.zeros((n_features, n_alphas), order='F')  # sklearn API
-    thetas = np.zeros((n_alphas, n_samples))
+    coefs = np.zeros((n_features, n_alphas), order='F', dtype=X.dtype)
+    thetas = np.zeros((n_alphas, n_samples), dtype=X.dtype)
     dual_gaps = np.zeros(n_alphas)
     all_times = np.zeros(n_alphas)
 

--- a/celer/utils.pxd
+++ b/celer/utils.pxd
@@ -4,11 +4,11 @@
 # License: BSD 3 clause
 from cython cimport floating
 
-cdef double fmax(double, double) nogil
-cdef double fmin(double, double) nogil
-cdef double ST(double, double) nogil
-cdef double primal_value(double, int, double *, int, double *) nogil
-cdef double dual_value(int, double, double, double *, double *) nogil
+cdef floating fmax(floating, floating) nogil
+cdef floating fmin(floating, floating) nogil
+cdef floating ST(floating, floating) nogil
+cdef floating primal_value(floating, int, floating *, int, floating *) nogil
+cdef floating dual_value(int, floating, floating, floating *, floating *) nogil
 
 cdef floating fused_dot(int *, floating *, int *, floating *, int *) nogil
 cdef floating fused_asum(int *, floating *, int *) nogil
@@ -17,4 +17,5 @@ cdef floating fused_nrm2(int * , floating *, int *) nogil
 cdef void fused_copy(int *, floating *, int *, floating *, int *) nogil
 cdef void fused_scal(int *, floating *, floating *, int *) nogil
 
-# cdef double fused_posv
+cdef void fused_posv(char *, int *, int *, floating *,
+                     int *, floating *, int *, int *)

--- a/celer/utils.pxd
+++ b/celer/utils.pxd
@@ -4,8 +4,8 @@
 # License: BSD 3 clause
 from cython cimport floating
 
-cdef floating fmax(floating, floating) nogil
-cdef floating fmin(floating, floating) nogil
+# cdef floating fmax(floating, floating) nogil
+# cdef floating fmin(floating, floating) nogil
 cdef floating ST(floating, floating) nogil
 cdef floating primal_value(floating, int, floating *, int, floating *) nogil
 cdef floating dual_value(int, floating, floating, floating *, floating *) nogil
@@ -18,4 +18,4 @@ cdef void fused_copy(int *, floating *, int *, floating *, int *) nogil
 cdef void fused_scal(int *, floating *, floating *, int *) nogil
 
 cdef void fused_posv(char *, int *, int *, floating *,
-                     int *, floating *, int *, int *)
+                     int *, floating *, int *, int *) nogil

--- a/celer/utils.pxd
+++ b/celer/utils.pxd
@@ -2,9 +2,19 @@
 #         Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #         Joseph Salmon <joseph.salmon@telecom-paristech.fr>
 # License: BSD 3 clause
+from cython cimport floating
 
 cdef double fmax(double, double) nogil
 cdef double fmin(double, double) nogil
 cdef double ST(double, double) nogil
 cdef double primal_value(double, int, double *, int, double *) nogil
 cdef double dual_value(int, double, double, double *, double *) nogil
+
+cdef floating fused_dot(int *, floating *, int *, floating *, int *) nogil
+cdef floating fused_asum(int *, floating *, int *) nogil
+cdef void fused_axpy(int *, floating *, floating *, int *, floating *, int *) nogil
+cdef floating fused_nrm2(int * , floating *, int *) nogil
+cdef void fused_copy(int *, floating *, int *, floating *, int *) nogil
+cdef void fused_scal(int *, floating *, floating *, int *) nogil
+
+# cdef double fused_posv

--- a/celer/utils.pyx
+++ b/celer/utils.pyx
@@ -61,17 +61,17 @@ cdef void fused_scal(int * n, floating * alpha, floating * x,
 cdef void fused_posv(char * uplo, int * n, int * nrhs, floating * a,
                      int * lda, floating * b, int * ldb, int * info) nogil:
     if floating is double:
-        dposv(uplo, n, nrhs, a, lda, b, ldb, info_posv)
+        dposv(uplo, n, nrhs, a, lda, b, ldb, info)
     else:
-        sposv(uplo, n, nrhs, a, lda, b, ldb, info_posv)
+        sposv(uplo, n, nrhs, a, lda, b, ldb, info)
 
 
-cdef inline floating fmax(floating x, floating y) nogil:
-    return x if x > y else y
-
-
-cdef inline floating fmin(floating x, floating y) nogil:
-    return y if x > y else y
+# cdef inline floating fmax(floating x, floating y) nogil:
+#     return x if x > y else y
+#
+#
+# cdef inline floating fmin(floating x, floating y) nogil:
+#     return y if x > y else y
 
 
 cdef inline floating ST(floating u, floating x) nogil:
@@ -90,7 +90,7 @@ cdef floating primal_value(floating alpha, int n_samples, floating * R,
                          int n_features, floating * w) nogil:
     cdef int inc = 1
     # regularization term: alpha ||w||_1
-    cdef floating p_obj = alpha * dasum(&n_features, w, &inc)
+    cdef floating p_obj = alpha * fused_asum(&n_features, w, &inc)
     # R is passed as a pointer so no need to & it
     p_obj += fused_dot(&n_samples, R, &inc, R, &inc) / (2. * n_samples)
     return p_obj

--- a/celer/utils.pyx
+++ b/celer/utils.pyx
@@ -7,73 +7,9 @@ cimport cython
 
 from scipy.linalg.cython_blas cimport ddot, dasum, daxpy, dnrm2, dcopy, dscal
 from scipy.linalg.cython_blas cimport sdot, sasum, saxpy, snrm2, scopy, sscal
+from scipy.linalg.cython_lapack cimport sposv, dposv
 from libc.math cimport fabs
 from cython cimport floating
-
-
-cdef inline double fmax(double x, double y) nogil:
-    return x if x > y else y
-
-
-cdef inline double fmin(double x, double y) nogil:
-    return y if x > y else y
-
-
-# cdef inline double fsign(double x) nogil :
-#     if x == 0.:
-#         return 0.
-#     elif x > 0.:
-#         return 1.
-#     else:
-#         return - 1.
-
-
-cdef inline double ST(double u, double x) nogil:
-    if x > u:
-        return x - u
-    elif x < - u:
-        return x + u
-    else:
-        return 0
-
-
-# cdef double abs_max(int n, double * a) nogil:
-#     cdef int ii
-#     cdef double m = 0.
-#     cdef double d
-#     for ii in range(n):
-#         d = fabs(a[ii])
-#         if d > m:
-#             m = d
-#     return m
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
-cdef double primal_value(double alpha, int n_samples, double * R,
-                         int n_features, double * w) nogil:
-    cdef int inc = 1
-    # regularization term: alpha ||w||_1
-    cdef double p_obj = alpha * dasum(&n_features, w, &inc)
-    # R is passed as a pointer so no need to & it
-    p_obj += ddot(&n_samples, R, &inc, R, &inc) / (2. * n_samples)
-    return p_obj
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
-cdef double dual_value(int n_samples, double alpha, double norm_y2,
-                       double * theta, double * y) nogil:
-    """Theta must be feasible"""
-    cdef int i
-    cdef double d_obj = 0.
-    for i in range(n_samples):
-        d_obj -= (y[i] / (alpha * n_samples) - theta[i]) ** 2
-    d_obj *= 0.5 * alpha ** 2 * n_samples
-    d_obj += norm_y2 / (2. * n_samples)
-    return d_obj
 
 
 cdef floating fused_dot(int * n, floating * x, int * inc1, floating * y,
@@ -90,19 +26,20 @@ cdef floating fused_asum(int * n, floating * x, int * inc) nogil:
     else:
         return sasum(n, x, inc)
 
+
 cdef void fused_axpy(int * n, floating * alpha, floating * x, int * incx,
                      floating * y, int * incy) nogil:
-     if floating is double:
-         daxpy(n, alpha, x, incx, y, incy)
-     else:
-         saxpy(n, alpha, x, incx, y, incy)
+    if floating is double:
+        daxpy(n, alpha, x, incx, y, incy)
+    else:
+        saxpy(n, alpha, x, incx, y, incy)
 
 
 cdef floating fused_nrm2(int * n, floating * x, int * inc) nogil:
-     if floating is double:
-         return dnrm2(n, x, inc)
-     else:
-         return snrm2(n, x, inc)
+    if floating is double:
+        return dnrm2(n, x, inc)
+    else:
+        return snrm2(n, x, inc)
 
 
 cdef void fused_copy(int * n, floating * x, int * incx, floating * y,
@@ -119,3 +56,56 @@ cdef void fused_scal(int * n, floating * alpha, floating * x,
         dscal(n, alpha, x, incx)
     else:
         sscal(n, alpha, x, incx)
+
+
+cdef void fused_posv(char * uplo, int * n, int * nrhs, floating * a,
+                     int * lda, floating * b, int * ldb, int * info) nogil:
+    if floating is double:
+        dposv(uplo, n, nrhs, a, lda, b, ldb, info_posv)
+    else:
+        sposv(uplo, n, nrhs, a, lda, b, ldb, info_posv)
+
+
+cdef inline floating fmax(floating x, floating y) nogil:
+    return x if x > y else y
+
+
+cdef inline floating fmin(floating x, floating y) nogil:
+    return y if x > y else y
+
+
+cdef inline floating ST(floating u, floating x) nogil:
+    if x > u:
+        return x - u
+    elif x < - u:
+        return x + u
+    else:
+        return 0
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+cdef floating primal_value(floating alpha, int n_samples, floating * R,
+                         int n_features, floating * w) nogil:
+    cdef int inc = 1
+    # regularization term: alpha ||w||_1
+    cdef floating p_obj = alpha * dasum(&n_features, w, &inc)
+    # R is passed as a pointer so no need to & it
+    p_obj += fused_dot(&n_samples, R, &inc, R, &inc) / (2. * n_samples)
+    return p_obj
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+cdef floating dual_value(int n_samples, floating alpha, floating norm_y2,
+                       floating * theta, floating * y) nogil:
+    """Theta must be feasible"""
+    cdef int i
+    cdef floating d_obj = 0.
+    for i in range(n_samples):
+        d_obj -= (y[i] / (alpha * n_samples) - theta[i]) ** 2
+    d_obj *= 0.5 * alpha ** 2 * n_samples
+    d_obj += norm_y2 / (2. * n_samples)
+    return d_obj

--- a/celer/utils.pyx
+++ b/celer/utils.pyx
@@ -4,8 +4,11 @@
 # License: BSD 3 clause
 
 cimport cython
-from scipy.linalg.cython_blas cimport ddot, dasum
+
+from scipy.linalg.cython_blas cimport ddot, dasum, daxpy, dnrm2, dcopy, dscal
+from scipy.linalg.cython_blas cimport sdot, sasum, saxpy, snrm2, scopy, sscal
 from libc.math cimport fabs
+from cython cimport floating
 
 
 cdef inline double fmax(double x, double y) nogil:
@@ -71,3 +74,48 @@ cdef double dual_value(int n_samples, double alpha, double norm_y2,
     d_obj *= 0.5 * alpha ** 2 * n_samples
     d_obj += norm_y2 / (2. * n_samples)
     return d_obj
+
+
+cdef floating fused_dot(int * n, floating * x, int * inc1, floating * y,
+                        int * inc2) nogil:
+    if floating is double:
+        return ddot(n, x, inc1, y, inc2)
+    else:
+        return sdot(n, x, inc1, y, inc2)
+
+
+cdef floating fused_asum(int * n, floating * x, int * inc) nogil:
+    if floating is double:
+        return dasum(n, x, inc)
+    else:
+        return sasum(n, x, inc)
+
+cdef void fused_axpy(int * n, floating * alpha, floating * x, int * incx,
+                     floating * y, int * incy) nogil:
+     if floating is double:
+         daxpy(n, alpha, x, incx, y, incy)
+     else:
+         saxpy(n, alpha, x, incx, y, incy)
+
+
+cdef floating fused_nrm2(int * n, floating * x, int * inc) nogil:
+     if floating is double:
+         return dnrm2(n, x, inc)
+     else:
+         return snrm2(n, x, inc)
+
+
+cdef void fused_copy(int * n, floating * x, int * incx, floating * y,
+                     int * incy) nogil:
+    if floating is double:
+        dcopy(n, x, incx, y, incy)
+    else:
+        scopy(n, x, incx, y, incy)
+
+
+cdef void fused_scal(int * n, floating * alpha, floating * x,
+                     int * incx) nogil:
+    if floating is double:
+        dscal(n, alpha, x, incx)
+    else:
+        sscal(n, alpha, x, incx)

--- a/celer/wrapper.py
+++ b/celer/wrapper.py
@@ -88,10 +88,10 @@ def celer(X, y, alpha, beta_init=None, max_iter=100, gap_freq=10,
         if not X.has_sorted_indices:
             X.sort_indices()
     # cython function only accepts float64 for X and y:
-    if X.dtype != 'float64':
-        X = X.astype(np.float64)
-    if y.dtype != 'float64':
-        y = y.astype(np.float64)
+    # if X.dtype != 'float64':
+    #     X = X.astype(np.float64)
+    # if y.dtype != 'float64':
+    #     y = y.astype(np.float64)
 
     n_features = X.shape[1]
     if beta_init is None:


### PR DESCRIPTION
This way we avoid unnecessary copy of the data when X and y have dtype float32