### PR TITLE
ENH: have celer() call celer_path()

### DIFF
--- a/celer/sparse.pyx
+++ b/celer/sparse.pyx
@@ -82,12 +82,12 @@ cdef void set_feature_prios_sparse(int n_features, floating * theta,
 @cython.cdivision(True)
 def celer_sparse(
     floating[:] X_data, int[:] X_indices, int[:] X_indptr,
-    floating[:] y, floating alpha,  floating[:] w_init, int max_iter,
+    floating[:] y, floating alpha, floating[:] w_init, int max_iter,
     int max_epochs, int gap_freq=10, float tol_ratio_inner=0.3,
     float tol=1e-6, int p0=100, int screening=0, int verbose=0,
     int verbose_inner=0, int use_accel=1,  int return_ws_size=0,
     int prune=0):
-    
+
     if floating is double:
         dtype = np.float64
     else:

--- a/celer/tests/test_homotopy.py
+++ b/celer/tests/test_homotopy.py
@@ -11,7 +11,7 @@ from sklearn.utils.estimator_checks import check_estimator
 from sklearn.linear_model import (LassoCV as sklearn_LassoCV,
                                   Lasso as sklearn_Lasso, lasso_path)
 
-from celer import celer_path
+from celer import celer_path, celer
 from celer.dropin_sklearn import Lasso, LassoCV
 
 
@@ -105,3 +105,14 @@ def test_dropin_lasso(sparse_X):
     np.testing.assert_allclose(clf.coef_, clf2.coef_, rtol=1e-5)
 
     check_estimator(Lasso)
+
+
+def test_celer_single_alpha():
+    X, y, _, _ = build_dataset(n_samples=20, n_features=100)
+    alpha_max = np.linalg.norm(X.T.dot(y), ord=np.inf) / X.shape[0]
+
+    tol = 1e-6
+    w, theta, gaps, times = celer(X, y, alpha_max / 10., tol=tol)
+    np.testing.assert_array_less(gaps[-1], tol)
+    np.testing.assert_equal(w.shape[0], X.shape[1])
+    np.testing.assert_equal(theta.shape[0], X.shape[0])

--- a/celer/wrapper.py
+++ b/celer/wrapper.py
@@ -77,7 +77,9 @@ def celer(X, y, alpha, w_init=None, max_iter=100, gap_freq=10,
     """
 
     alphas, coefs, _, thetas, all_gaps, all_times = celer_path(
-        X, y, alphas=np.array(alpha), coef_init=w_init,
+        X, y, alphas=np.array(alpha), coef_init=w_init, gap_freq=gap_freq,
+        max_epochs=max_epochs, p0=p0, verbose=verbose,
+        verbose_inner=verbose_inner, tol=tol, prune=prune, return_thetas=True,
         monitor=True)
 
     w = coefs.T[0]

--- a/celer/wrapper.py
+++ b/celer/wrapper.py
@@ -4,11 +4,12 @@
 # License: BSD 3 clause
 
 import numpy as np
-import warnings
+# import warnings
 
-from sklearn.exceptions import ConvergenceWarning
+# from sklearn.exceptions import ConvergenceWarning
 
 from .homotopy import celer_path
+
 
 def celer(X, y, alpha, w_init=None, max_iter=100, gap_freq=10,
           max_epochs=50000, p0=10, verbose=1, verbose_inner=0,
@@ -77,7 +78,7 @@ def celer(X, y, alpha, w_init=None, max_iter=100, gap_freq=10,
     """
 
     alphas, coefs, _, thetas, all_gaps, all_times = celer_path(
-        X, y, alphas=np.array(alpha), coef_init=w_init, gap_freq=gap_freq,
+        X, y, alphas=np.array([alpha]), coef_init=w_init, gap_freq=gap_freq,
         max_epochs=max_epochs, p0=p0, verbose=verbose,
         verbose_inner=verbose_inner, tol=tol, prune=prune, return_thetas=True,
         monitor=True)

--- a/celer/wrapper.py
+++ b/celer/wrapper.py
@@ -6,12 +6,9 @@
 import numpy as np
 import warnings
 
-from scipy import sparse
 from sklearn.exceptions import ConvergenceWarning
 
-from .sparse import celer_sparse
-from .dense import celer_dense
-
+from .homotopy import celer_path
 
 def celer(X, y, alpha, w_init=None, max_iter=100, gap_freq=10,
           max_epochs=50000, p0=10, verbose=1, verbose_inner=0,
@@ -78,42 +75,22 @@ def celer(X, y, alpha, w_init=None, max_iter=100, gap_freq=10,
     times : array
         Time elapsed since entering the solver, at each outer loop iteration.
     """
-    data_is_sparse = sparse.issparse(X)
-    if not data_is_sparse:
-        if not np.isfortran(X):
-            X = np.asfortranarray(X)
-    else:
-        if X.getformat() != 'csc':
-            raise TypeError("Sparse X must be in column sparse format.")
-        if not X.has_sorted_indices:
-            X.sort_indices()
 
-    n_features = X.shape[1]
-    if w_init is None:
-        w_init = np.zeros(n_features)
+    alphas, coefs, _, thetas, all_gaps, all_times = celer_path(
+        X, y, alphas=np.array(alpha), coef_init=w_init,
+        monitor=True)
 
-    if data_is_sparse:
-        sol = celer_sparse(X.data, X.indices, X.indptr, y, alpha,
-                           w_init, max_iter=max_iter, gap_freq=gap_freq,
-                           max_epochs=max_epochs, p0=p0,
-                           verbose=verbose,
-                           verbose_inner=verbose_inner,
-                           use_accel=1, tol=tol, prune=prune)
-    else:
-        sol = celer_dense(X, y, alpha,
-                          w_init, max_iter=max_iter, gap_freq=gap_freq,
-                          max_epochs=max_epochs, p0=p0,
-                          verbose=verbose,
-                          verbose_inner=verbose_inner,
-                          use_accel=1, tol=tol, prune=prune)
+    w = coefs.T[0]
+    theta = thetas[0]
+    gaps = all_gaps[0]
+    times = all_times[0]
 
-    final_gap = sol[2][-1]
-    if final_gap > tol:
-        warnings.warn('Objective did not converge.' +
-                      ' You might want' +
-                      ' to increase the number of iterations.' +
-                      ' Fitting data with very small alpha' +
-                      ' may cause precision problems.',
-                      ConvergenceWarning)
+    # if final_gap > tol:
+    #     warnings.warn('Objective did not converge.' +
+    #                   ' You might want' +
+    #                   ' to increase the number of iterations.' +
+    #                   ' Fitting data with very small alpha' +
+    #                   ' may cause precision problems.',
+    #                   ConvergenceWarning)
 
-    return sol
+    return w, theta, gaps, times


### PR DESCRIPTION
Currently the order is reversed, so checks on X and y are performed for every alpha.

sklearn does it the other way: when a single lambda needs to be fitted, we pretend it's a path of length 1.
The key is to be able to pass a `coef_init` for the first value of the path, which I wwasn't doing earlier.
I need the order to be reversed for #20 