### PR TITLE
FIX: p0 parameter being ignored in celer_path()

### DIFF
--- a/celer/homotopy.py
+++ b/celer/homotopy.py
@@ -147,10 +147,9 @@ def celer_path(X, y, eps=1e-3, n_alphas=100, alphas=None,
         else:
             if coef_init is not None:
                 w_init = coef_init.copy()
-                p0 = max((w_init != 0.).sum(), 10)
+                p0 = max((w_init != 0.).sum(), p0)
             else:
                 w_init = np.zeros(n_features, dtype=X.dtype)
-                p0 = 10
 
         alpha = alphas[t]
         t0 = time.time()


### PR DESCRIPTION
p0 = 10 was hardcoded inside this function, so no matter which value was passed, p0 = 10 was used.