### PR TITLE
FIX use stock joblib

### DIFF
--- a/celer/dropin_sklearn.py
+++ b/celer/dropin_sklearn.py
@@ -10,7 +10,7 @@ from sklearn.utils import check_array
 from sklearn.externals import six
 from sklearn.utils.validation import column_or_1d
 from sklearn.model_selection import check_cv
-from sklearn.externals.joblib import Parallel, delayed, effective_n_jobs
+from joblib import Parallel, delayed, effective_n_jobs
 from sklearn.utils.fixes import _joblib_parallel_args
 from sklearn.linear_model import ElasticNetCV, lasso_path
 from sklearn.linear_model import (Lasso as Lasso_sklearn,


### PR DESCRIPTION
In recent `scikit-learn` version, the use of `sklear.external.joblib` has been deprecated. It should now be used directly from `joblib`.