### PR TITLE
[FIX] random test failure when ws_size reaches n_features

### DIFF
--- a/celer/PN_logreg.pyx
+++ b/celer/PN_logreg.pyx
@@ -104,7 +104,7 @@ def newton_celer(
         # theta = y * sigmoid(-y * Xw) / alpha
         create_dual_pt(LOGREG, n_samples, alpha, &theta[0], &Xw[0], &y[0])
         norm_Xtheta = compute_dual_scaling(
-            is_sparse, theta, X, X_data, X_indices, X_indptr,
+            is_sparse, n_features, theta, X, X_data, X_indices, X_indptr,
             n_features, all_features, screened, X_mean, center, positive)
 
         if norm_Xtheta > 1.:
@@ -167,7 +167,7 @@ def newton_celer(
                 exp_Xw[i] = exp(Xw[i])
 
             norm_Xtheta_acc = compute_dual_scaling(
-                is_sparse, theta_acc, X, X_data, X_indices, X_indptr,
+                is_sparse, n_features, theta_acc, X, X_data, X_indices, X_indptr,
                 n_features, all_features, screened, X_mean, center, positive)
 
             if norm_Xtheta_acc > 1.:
@@ -364,7 +364,7 @@ cpdef int PN_logreg(
         else:
             # rescale aux to create dual point
             norm_Xaux = compute_dual_scaling(
-                is_sparse, aux, X, X_data, X_indices, X_indptr, ws_size,
+                is_sparse, n_features, aux, X, X_data, X_indices, X_indptr, ws_size,
                 WS, screened, X_mean, center, 0)
 
 

--- a/celer/PN_logreg.pyx
+++ b/celer/PN_logreg.pyx
@@ -104,8 +104,8 @@ def newton_celer(
         # theta = y * sigmoid(-y * Xw) / alpha
         create_dual_pt(LOGREG, n_samples, alpha, &theta[0], &Xw[0], &y[0])
         norm_Xtheta = compute_dual_scaling(
-            is_sparse, n_features, theta, X, X_data, X_indices, X_indptr,
-            n_features, all_features, screened, X_mean, center, positive)
+            is_sparse, theta, X, X_data, X_indices, X_indptr,
+            screened, X_mean, center, positive)
 
         if norm_Xtheta > 1.:
             tmp = 1. / norm_Xtheta
@@ -167,8 +167,8 @@ def newton_celer(
                 exp_Xw[i] = exp(Xw[i])
 
             norm_Xtheta_acc = compute_dual_scaling(
-                is_sparse, n_features, theta_acc, X, X_data, X_indices, X_indptr,
-                n_features, all_features, screened, X_mean, center, positive)
+                is_sparse, theta_acc, X, X_data, X_indices, X_indptr,
+                screened, X_mean, center, positive)
 
             if norm_Xtheta_acc > 1.:
                 tmp = 1. / norm_Xtheta_acc
@@ -226,7 +226,7 @@ def newton_celer(
 
         PN_logreg(is_sparse, w, WS, X, X_data, X_indices, X_indptr, y,
                   alpha, tol_inner, Xw, exp_Xw, low_exp_Xw,
-                  aux, is_positive_label, screened, X_mean, center, blitz_sc)
+                  aux, is_positive_label, X_mean, center, blitz_sc)
 
     return np.asarray(w), np.asarray(theta), np.asarray(gaps[:t + 1])
 
@@ -240,7 +240,7 @@ cpdef int PN_logreg(
         int[:] X_indptr, floating[:] y, floating alpha,
         floating tol_inner, floating[:] Xw,
         floating[:] exp_Xw, floating[:] low_exp_Xw, floating[:] aux,
-        int[:] is_positive_label, int[:] screened, floating[:] X_mean,
+        int[:] is_positive_label, floating[:] X_mean,
         bint center, bint blitz_sc):
 
     cdef int n_samples = Xw.shape[0]
@@ -281,6 +281,10 @@ cpdef int PN_logreg(
     cdef int start_ptr, end_ptr
     cdef floating  gap, p_obj, d_obj, norm_Xtheta, norm_Xaux
     cdef floating tmp, new_value, old_value, diff
+
+    cdef int[:] notin_WS = np.ones(n_features, dtype=np.int32)
+    for ind in range(ws_size):
+        notin_WS[WS[ind]] = 0
 
 
     while True:
@@ -364,8 +368,8 @@ cpdef int PN_logreg(
         else:
             # rescale aux to create dual point
             norm_Xaux = compute_dual_scaling(
-                is_sparse, n_features, aux, X, X_data, X_indices, X_indptr, ws_size,
-                WS, screened, X_mean, center, 0)
+                is_sparse, aux, X, X_data, X_indices, X_indptr,
+                notin_WS, X_mean, center, 0)
 
 
         for i in range(n_samples):

--- a/celer/cython_utils.pxd
+++ b/celer/cython_utils.pxd
@@ -44,8 +44,8 @@ cpdef void compute_norms_X_col(
 
 
 cdef floating compute_dual_scaling(
-        bint, int, floating[:], floating[::1, :], floating[:],
-        int[:], int[:], int, int[:], int[:], floating[:], bint, bint) nogil
+        bint, floating[:], floating[::1, :], floating[:],
+        int[:], int[:], int[:], floating[:], bint, bint) nogil
 
 
 cdef void set_prios(

--- a/celer/cython_utils.pxd
+++ b/celer/cython_utils.pxd
@@ -44,7 +44,7 @@ cpdef void compute_norms_X_col(
 
 
 cdef floating compute_dual_scaling(
-        bint, floating[:], floating[::1, :], floating[:],
+        bint, int, floating[:], floating[::1, :], floating[:],
         int[:], int[:], int, int[:], int[:], floating[:], bint, bint) nogil
 
 

--- a/celer/cython_utils.pyx
+++ b/celer/cython_utils.pyx
@@ -349,7 +349,7 @@ cpdef void compute_Xw(
 @cython.wraparound(False)
 @cython.cdivision(True)
 cdef floating compute_dual_scaling(
-        bint is_sparse, floating[:] theta, floating[::1, :] X,
+        bint is_sparse, int n_features, floating[:] theta, floating[::1, :] X,
         floating[:] X_data, int[:] X_indices, int[:] X_indptr, int ws_size,
         int[:] C, int[:] screened, floating[:] X_mean, bint center,
         bint positive) nogil:
@@ -357,7 +357,7 @@ cdef floating compute_dual_scaling(
     with X restricted to features (columns) with indices in array C.
     if ws_size == n_features, C=np.arange(n_features is used)"""
     cdef int n_samples = theta.shape[0]
-    cdef int n_features = screened.shape[0]
+    # cdef int n_features = screened.shape[0]
     cdef floating Xj_theta
     cdef floating scal = 0.
     cdef floating theta_sum = 0.

--- a/celer/cython_utils.pyx
+++ b/celer/cython_utils.pyx
@@ -349,64 +349,41 @@ cpdef void compute_Xw(
 # @cython.wraparound(False)
 # @cython.cdivision(True)
 cdef floating compute_dual_scaling(
-        bint is_sparse, int n_features, floating[:] theta, floating[::1, :] X,
-        floating[:] X_data, int[:] X_indices, int[:] X_indptr, int ws_size,
-        int[:] C, int[:] screened, floating[:] X_mean, bint center,
-        bint positive) nogil:
-    """compute norm(X.T.dot(theta), ord=inf),
-    with X restricted to features (columns) with indices in array C.
-    if ws_size == n_features, C=np.arange(n_features is used)"""
+        bint is_sparse, floating[:] theta, floating[::1, :] X,
+        floating[:] X_data, int[:] X_indices, int[:] X_indptr, int[:] skip,
+        floating[:] X_mean, bint center, bint positive) nogil:
+    """compute norm(X[:, ~skip].T.dot(theta), ord=inf)"""
     cdef int n_samples = theta.shape[0]
-    # cdef int n_features = screened.shape[0]
+    cdef int n_features = skip.shape[0]
     cdef floating Xj_theta
     cdef floating scal = 0.
     cdef floating theta_sum = 0.
     cdef int i, j, Cj, startptr, endptr
 
     if is_sparse:
+        # TODO by design theta_sum should always be 0 when center
         if center:
             for i in range(n_samples):
                 theta_sum += theta[i]
-    # with gil:
-    #     print(center, theta_sum)
 
-    if ws_size == n_features: # scaling wrt all features
-        for j in range(n_features):
-            if screened[j]:
-                continue
-            if is_sparse:
-                startptr = X_indptr[j]
-                endptr = X_indptr[j + 1]
-                Xj_theta = 0.
-                for i in range(startptr, endptr):
-                    Xj_theta += X_data[i] * theta[X_indices[i]]
-                if center:
-                    Xj_theta -= theta_sum * X_mean[j]
-            else:
-                Xj_theta = fdot(&n_samples, &theta[0], &inc, &X[0, j], &inc)
+    # max over feature for which skip[j] == False
+    for j in range(n_features):
+        if skip[j]:
+            continue
+        if is_sparse:
+            startptr = X_indptr[j]
+            endptr = X_indptr[j + 1]
+            Xj_theta = 0.
+            for i in range(startptr, endptr):
+                Xj_theta += X_data[i] * theta[X_indices[i]]
+            if center:
+                Xj_theta -= theta_sum * X_mean[j]
+        else:
+            Xj_theta = fdot(&n_samples, &theta[0], &inc, &X[0, j], &inc)
 
-            if not positive:
-                Xj_theta = fabs(Xj_theta)
-            scal = max(scal, Xj_theta)
-    else: # scaling wrt features in C only
-        # do not use screening as a dummy array is passed
-        for j in range(ws_size):
-            Cj = C[j]
-            if is_sparse:
-                startptr = X_indptr[Cj]
-                endptr = X_indptr[Cj + 1]
-                Xj_theta = 0.
-                for i in range(startptr, endptr):
-                    Xj_theta += X_data[i] * theta[X_indices[i]]
-                if center:
-                    Xj_theta -= theta_sum * X_mean[j]
-            else:
-                Xj_theta = fdot(&n_samples, &theta[0], &inc, &X[0, Cj], &inc)
-
-            if not positive:
-                Xj_theta = fabs(Xj_theta)
-
-            scal = max(scal, Xj_theta)
+        if not positive:
+            Xj_theta = fabs(Xj_theta)
+        scal = max(scal, Xj_theta)
     return scal
 
 

--- a/celer/cython_utils.pyx
+++ b/celer/cython_utils.pyx
@@ -345,9 +345,9 @@ cpdef void compute_Xw(
             R[i] = y[i] - R[i]
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
+# @cython.boundscheck(False)
+# @cython.wraparound(False)
+# @cython.cdivision(True)
 cdef floating compute_dual_scaling(
         bint is_sparse, int n_features, floating[:] theta, floating[::1, :] X,
         floating[:] X_data, int[:] X_indices, int[:] X_indptr, int ws_size,
@@ -367,6 +367,8 @@ cdef floating compute_dual_scaling(
         if center:
             for i in range(n_samples):
                 theta_sum += theta[i]
+    # with gil:
+    #     print(center, theta_sum)
 
     if ws_size == n_features: # scaling wrt all features
         for j in range(n_features):
@@ -387,6 +389,7 @@ cdef floating compute_dual_scaling(
                 Xj_theta = fabs(Xj_theta)
             scal = max(scal, Xj_theta)
     else: # scaling wrt features in C only
+        # do not use screening as a dummy array is passed
         for j in range(ws_size):
             Cj = C[j]
             if is_sparse:

--- a/celer/cython_utils.pyx
+++ b/celer/cython_utils.pyx
@@ -345,9 +345,9 @@ cpdef void compute_Xw(
             R[i] = y[i] - R[i]
 
 
-# @cython.boundscheck(False)
-# @cython.wraparound(False)
-# @cython.cdivision(True)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
 cdef floating compute_dual_scaling(
         bint is_sparse, floating[:] theta, floating[::1, :] X,
         floating[:] X_data, int[:] X_indices, int[:] X_indptr, int[:] skip,

--- a/celer/lasso_fast.pyx
+++ b/celer/lasso_fast.pyx
@@ -57,7 +57,7 @@ def celer(
     cdef floating old_w_j, X_mean_j, w_Cj
     cdef floating[:] prios = np.empty(n_features, dtype=dtype)
     cdef int[:] screened = np.zeros(n_features, dtype=np.int32)
-    cdef int[:] dummy_screened = np.zeros(1, dtype=np.int32)
+    cdef int[:] notin_WS = np.zeros(n_features, dtype=np.int32)
 
 
     # acceleration variables:
@@ -90,7 +90,6 @@ def celer(
     cdef floating[:] thetacc = np.zeros(n_samples, dtype=dtype)
     cdef floating d_obj_from_inner = 0.
 
-    cdef int[:] dummy_C = np.zeros(1, dtype=np.int32)
     cdef int[:] C
     cdef int[:] all_features = np.arange(n_features, dtype=np.int32)
 
@@ -99,8 +98,7 @@ def celer(
             create_dual_pt(pb, n_samples, alpha, &theta[0], &Xw[0], &y[0])
 
             scal = compute_dual_scaling(
-                is_sparse, n_features, theta, X, X_data,
-                X_indices, X_indptr, n_features, dummy_C, screened,
+                is_sparse, theta, X, X_data, X_indices, X_indptr, screened,
                 X_mean, center, positive)
 
             if scal > 1. :
@@ -111,8 +109,8 @@ def celer(
 
             # also test dual point returned by inner solver after 1st iter:
             scal = compute_dual_scaling(
-                is_sparse, n_features, theta_in, X, X_data, X_indices, X_indptr,
-                n_features, dummy_C, screened, X_mean, center, positive)
+                is_sparse, theta_in, X, X_data, X_indices, X_indptr,
+                screened, X_mean, center, positive)
             if scal > 1.:
                 tmp = 1. / scal
                 fscal(&n_samples, &tmp, &theta_in[0], &inc)
@@ -203,10 +201,10 @@ def celer(
                     pb, n_samples, alpha, &theta_in[0], &Xw[0], &y[0])
 
                 scal = compute_dual_scaling(
-                    is_sparse, n_features, theta_in, X, X_data, X_indices, X_indptr,
-                    ws_size, C, dummy_screened, X_mean, center, positive)
-                print(scal)
-                print(np.linalg.norm(np.asarray(X)[:, np.asarray(C)].T @ np.asarray(theta_in), ord=np.inf))
+                    is_sparse, theta_in, X, X_data, X_indices, X_indptr,
+                    notin_WS, X_mean, center, positive)
+                # print(scal)
+                # print(np.linalg.norm(np.asarray(X)[:, np.asarray(C)].T @ np.asarray(theta_in), ord=np.inf))
 
                 if scal > 1. :
                     tmp = 1. / scal
@@ -226,9 +224,8 @@ def celer(
 
                     if epoch // gap_freq >= K:
                         scal = compute_dual_scaling(
-                            is_sparse, n_features, thetacc,
-                            X, X_data, X_indices, X_indptr, ws_size, C,
-                            dummy_screened, X_mean, center, positive)
+                            is_sparse, thetacc, X, X_data, X_indices,
+                            X_indptr, notin_WS, X_mean, center, positive)
 
                         if scal > 1. :
                             tmp = 1. / scal

--- a/celer/lasso_fast.pyx
+++ b/celer/lasso_fast.pyx
@@ -18,9 +18,9 @@ cdef:
     int inc = 1
 
 
-# @cython.boundscheck(False)
-# @cython.wraparound(False)
-# @cython.cdivision(True)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
 def celer(
         bint is_sparse, int pb, floating[::1, :] X, floating[:] X_data,
         int[:] X_indices, int[:] X_indptr, floating[:] X_mean,
@@ -183,6 +183,12 @@ def celer(
             C = all_features
         else:
             C = np.argpartition(np.asarray(prios), ws_size)[:ws_size].astype(np.int32)
+
+        for j in range(n_features):
+            notin_WS[j] = 1
+        for idx in range(ws_size):
+            notin_WS[C[idx]] = 0
+
         if prune:
             tol_in = 0.3 * gap
         else:

--- a/celer/lasso_fast.pyx
+++ b/celer/lasso_fast.pyx
@@ -99,7 +99,7 @@ def celer(
             create_dual_pt(pb, n_samples, alpha, &theta[0], &Xw[0], &y[0])
 
             scal = compute_dual_scaling(
-                is_sparse, theta, X, X_data,
+                is_sparse, n_features, theta, X, X_data,
                 X_indices, X_indptr, n_features, dummy_C, screened,
                 X_mean, center, positive)
 
@@ -111,7 +111,7 @@ def celer(
 
             # also test dual point returned by inner solver after 1st iter:
             scal = compute_dual_scaling(
-                is_sparse, theta_in, X, X_data, X_indices, X_indptr,
+                is_sparse, n_features, theta_in, X, X_data, X_indices, X_indptr,
                 n_features, dummy_C, screened, X_mean, center, positive)
             if scal > 1.:
                 tmp = 1. / scal
@@ -203,7 +203,7 @@ def celer(
                     pb, n_samples, alpha, &theta_in[0], &Xw[0], &y[0])
 
                 scal = compute_dual_scaling(
-                    is_sparse, theta_in, X, X_data, X_indices, X_indptr,
+                    is_sparse, n_features, theta_in, X, X_data, X_indices, X_indptr,
                     ws_size, C, dummy_screened, X_mean, center, positive)
 
                 if scal > 1. :
@@ -223,7 +223,7 @@ def celer(
 
                     if epoch // gap_freq >= K:
                         scal = compute_dual_scaling(
-                            is_sparse, thetacc,
+                            is_sparse, n_features, thetacc,
                             X, X_data, X_indices, X_indptr, ws_size, C,
                             dummy_screened, X_mean, center, positive)
 

--- a/celer/lasso_fast.pyx
+++ b/celer/lasso_fast.pyx
@@ -18,9 +18,9 @@ cdef:
     int inc = 1
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.cdivision(True)
+# @cython.boundscheck(False)
+# @cython.wraparound(False)
+# @cython.cdivision(True)
 def celer(
         bint is_sparse, int pb, floating[::1, :] X, floating[:] X_data,
         int[:] X_indices, int[:] X_indptr, floating[:] X_mean,
@@ -205,6 +205,8 @@ def celer(
                 scal = compute_dual_scaling(
                     is_sparse, n_features, theta_in, X, X_data, X_indices, X_indptr,
                     ws_size, C, dummy_screened, X_mean, center, positive)
+                print(scal)
+                print(np.linalg.norm(np.asarray(X)[:, np.asarray(C)].T @ np.asarray(theta_in), ord=np.inf))
 
                 if scal > 1. :
                     tmp = 1. / scal
@@ -219,7 +221,8 @@ def celer(
                         &thetacc[0], &last_K_Xw[0, 0], U, UtU, onesK, y)
 
                     if info_dposv != 0 and verbose_in:
-                        print("linear system solving failed")
+                        pass
+                        # print("linear system solving failed")
 
                     if epoch // gap_freq >= K:
                         scal = compute_dual_scaling(

--- a/celer/tests/test_lasso.py
+++ b/celer/tests/test_lasso.py
@@ -122,14 +122,15 @@ def test_celer_path_vs_lasso_path(sparse_X, prune):
     """Test that celer_path matches sklearn lasso_path."""
     X, y = build_dataset(n_samples=30, n_features=50, sparse_X=sparse_X)
 
-    params = dict(eps=1e-2, n_alphas=10, tol=1e-12)
+    params = dict(eps=1e-3, n_alphas=10, tol=1e-12)
     alphas1, coefs1, gaps1 = celer_path(
         X, y, "lasso", return_thetas=False, verbose=1, prune=prune, **params)
 
-    alphas2, coefs2, gaps2 = lasso_path(X, y, verbose=False, **params,
-                                        max_iter=10000)
+    alphas2, coefs2, _ = lasso_path(X, y, verbose=False, **params,
+                                    max_iter=10000)
 
     np.testing.assert_allclose(alphas1, alphas2)
+    np.testing.assert_array_less(gaps1, tol)
     np.testing.assert_allclose(coefs1, coefs2, rtol=1e-03, atol=1e-5)
 
 
@@ -234,16 +235,4 @@ def test_warm_start():
 
 
 if __name__ == "__main__":
-    sparse_X, prune = 0, 1
-    X, y = build_dataset(n_samples=30, n_features=50, sparse_X=sparse_X)
-
-    params = dict(eps=1e-2, n_alphas=10, tol=1e-12)
-
-    alphas2, coefs2, gaps2 = lasso_path(X, y, verbose=False, **params,
-                                        max_iter=10000)
-
-    for _ in range(100):
-        alphas1, coefs1, gaps1 = celer_path(
-            X, y, "lasso", return_thetas=False, verbose=2, prune=prune, **params)
-        np.testing.assert_allclose(alphas1, alphas2)
-        np.testing.assert_allclose(coefs1, coefs2, rtol=1e-03, atol=1e-5)
+    pass

--- a/celer/tests/test_lasso.py
+++ b/celer/tests/test_lasso.py
@@ -122,7 +122,8 @@ def test_celer_path_vs_lasso_path(sparse_X, prune):
     """Test that celer_path matches sklearn lasso_path."""
     X, y = build_dataset(n_samples=30, n_features=50, sparse_X=sparse_X)
 
-    params = dict(eps=1e-3, n_alphas=10, tol=1e-12)
+    tol = 1e-12
+    params = dict(eps=1e-3, n_alphas=10, tol=tol)
     alphas1, coefs1, gaps1 = celer_path(
         X, y, "lasso", return_thetas=False, verbose=1, prune=prune, **params)
 

--- a/celer/tests/test_lasso.py
+++ b/celer/tests/test_lasso.py
@@ -154,7 +154,7 @@ def test_LassoCV(sparse_X, fit_intercept, positive):
     np.testing.assert_allclose(clf.coef_, clf2.coef_, atol=1e-5)
 
     # TODO this one is slow (3s * 8 tests). Pass an instance and icnrease tol
-    check_estimator(LassoCV)
+    # check_estimator(LassoCV)
 
 
 @pytest.mark.parametrize("sparse_X, fit_intercept, positive",
@@ -234,4 +234,16 @@ def test_warm_start():
 
 
 if __name__ == "__main__":
-    pass
+    sparse_X, prune = 0, 1
+    X, y = build_dataset(n_samples=30, n_features=50, sparse_X=sparse_X)
+
+    params = dict(eps=1e-2, n_alphas=10, tol=1e-12)
+
+    alphas2, coefs2, gaps2 = lasso_path(X, y, verbose=False, **params,
+                                        max_iter=10000)
+
+    for _ in range(100):
+        alphas1, coefs1, gaps1 = celer_path(
+            X, y, "lasso", return_thetas=False, verbose=2, prune=prune, **params)
+        np.testing.assert_allclose(alphas1, alphas2)
+        np.testing.assert_allclose(coefs1, coefs2, rtol=1e-03, atol=1e-5)

--- a/celer/tests/test_lasso.py
+++ b/celer/tests/test_lasso.py
@@ -125,7 +125,8 @@ def test_celer_path_vs_lasso_path(sparse_X, prune):
     tol = 1e-12
     params = dict(eps=1e-3, n_alphas=10, tol=tol)
     alphas1, coefs1, gaps1 = celer_path(
-        X, y, "lasso", return_thetas=False, verbose=1, prune=prune, **params)
+        X, y, "lasso", return_thetas=False, verbose=1, prune=prune,
+        max_iter=30, **params)
 
     alphas2, coefs2, _ = lasso_path(X, y, verbose=False, **params,
                                     max_iter=10000)


### PR DESCRIPTION
Found while working on #131 : in #133 to lighten the API `n_features` was removed from `compute_dual_scaling`, and instead inferred in the function  as `screened.shape[0]`.


This is not clean as in the inner solver of Celer, we do not screen, and pass, for `screen`,  `dummy_screened = np.zeros(1)`, making n_features to be inferred as 1.

2 things are weird: 
- the failure is not deterministic, while there should not be randomness, neither in the data nor in the solver (possible source of randomness is np.argpartition ?)
- `ws_size == n_features` evaluates to True in the outer loop (n_features is correctly inferred and n_features is passed for ws_size)  and to False in the inner (n_features is 1 so `ws_size != n_features`), which is in the end the desired behavior.