### PR TITLE
FIX: theta for lasso is R / (alpha * n_samples) not R / alpha

### DIFF
--- a/celer/cython_utils.pyx
+++ b/celer/cython_utils.pyx
@@ -195,7 +195,8 @@ cdef void create_dual_pt(
         floating * R, floating * y) nogil:
     """It is scaled by alpha for both Lasso and Logreg"""
     cdef floating tmp = 1. / alpha
-    if pb == LASSO:  # out = R / alpha
+    if pb == LASSO:  # out = R / (alpha * n_samples)
+        tmp /= n_samples
         fcopy(&n_samples, &R[0], &inc, &out[0], &inc)
     else:  # out = y * sigmoid(-y * Xw) / alpha
         for i in range(n_samples):

--- a/celer/homotopy.py
+++ b/celer/homotopy.py
@@ -155,7 +155,7 @@ def celer_path(X, y, pb, eps=1e-3, n_alphas=100, alphas=None,
     is_sparse = sparse.issparse(X)
 
     X = check_array(X, 'csc', dtype=[np.float64, np.float32],
-                    order='F', copy=False)
+                    order='F', copy=False, accept_large_sparse=False)
     y = check_array(y, 'csc', dtype=X.dtype.type, order='F', copy=False,
                     ensure_2d=False)
 

--- a/celer/tests/test_lasso.py
+++ b/celer/tests/test_lasso.py
@@ -182,7 +182,7 @@ def test_Lasso(sparse_X, fit_intercept, positive):
     if fit_intercept:
         np.testing.assert_allclose(clf.intercept_, clf2.intercept_)
 
-    check_estimator(Lasso)
+    check_estimator(clf)
 
 
 @pytest.mark.parametrize("sparse_X, pb",

--- a/celer/tests/test_lasso.py
+++ b/celer/tests/test_lasso.py
@@ -143,8 +143,7 @@ def test_LassoCV(sparse_X, fit_intercept, positive):
 
     X, y = build_dataset(n_samples=20, n_features=30, sparse_X=sparse_X)
     params = dict(eps=0.05, n_alphas=10, tol=1e-10, cv=2,
-                  fit_intercept=fit_intercept, positive=positive, verbose=2,
-                  n_jobs=-1)
+                  fit_intercept=fit_intercept, positive=positive, n_jobs=-1)
 
     clf = LassoCV(**params)
     clf.fit(X, y)
@@ -182,7 +181,7 @@ def test_Lasso(sparse_X, fit_intercept, positive):
     if fit_intercept:
         np.testing.assert_allclose(clf.intercept_, clf2.intercept_)
 
-    check_estimator(clf)
+    check_estimator(Lasso)
 
 
 @pytest.mark.parametrize("sparse_X, pb",


### PR DESCRIPTION
it's problematic when alpha > alpha_max is passed (which probably happens in check_estimator and caused the infinite loops I saw in #135 

Tests now fail because `ValueError: buffer source array is read-only``