### PR TITLE
FIX compatibility with scikit-learn, when cloning over multiple processes

### DIFF
--- a/celer/dropin_sklearn.py
+++ b/celer/dropin_sklearn.py
@@ -930,7 +930,7 @@ class GroupLassoCV(LassoCV, sklearn_LinearModelCV):
     p0 : int, optional (default=10)
         Number of features in the first working set.
 
-    prune : bool, optional (default=False)
+    prune : bool, optional (default=True)
         Whether to use pruning when growing the working sets.
 
     precompute : ignored parameter, kept for sklearn compatibility.
@@ -986,6 +986,7 @@ class GroupLassoCV(LassoCV, sklearn_LinearModelCV):
         self.max_epochs = max_epochs
         self.p0 = p0
         self.prune = prune
+        self.precompute = precompute
 
     def path(self, X, y, alphas, coef_init=None, **kwargs):
         """Compute GroupLasso path with Celer."""

--- a/celer/tests/test_mtl.py
+++ b/celer/tests/test_mtl.py
@@ -8,7 +8,7 @@ from sklearn.linear_model import MultiTaskLassoCV as sklearn_MultiTaskLassoCV
 from sklearn.linear_model import MultiTaskLasso as sklearn_MultiTaskLasso
 from sklearn.linear_model import lasso_path
 
-from celer import (Lasso, GroupLasso, MultiTaskLasso,
+from celer import (Lasso, GroupLasso, GroupLassoCV, MultiTaskLasso,
                    MultiTaskLassoCV)
 from celer.homotopy import celer_path, mtl_path, _grp_converter
 from celer.group_fast import dnorm_grp
@@ -179,7 +179,23 @@ def test_GroupLasso(sparse_X):
     np.testing.assert_array_less(clf.dual_gap_, tol)
 
     clf.tol = 1e-6
-    clf.groups = 1  # unsatisfying but sklearn will fit of 5 features
+    clf.groups = 1  # unsatisfying but sklearn will fit out of 5 features
+    check_estimator(clf)
+
+
+@pytest.mark.parametrize("sparse_X", [True, False])
+def test_GroupLassoCV(sparse_X):
+    n_features = 50
+    X, y = build_dataset(
+        n_samples=11, n_features=n_features, sparse_X=sparse_X)
+
+    tol = 1e-8
+    clf = GroupLassoCV(groups=10, tol=tol)
+    clf.fit(X, y)
+    np.testing.assert_array_less(clf.dual_gap_, tol)
+
+    clf.tol = 1e-6
+    clf.groups = 1  # unsatisfying but sklearn will fit with 5 features
     check_estimator(clf)
 
 


### PR DESCRIPTION
Fix a subtle compatibility issue with scikit-learn, when cloning over multiple processes.
```py
import numpy as np
from sklearn.multioutput import MultiOutputRegressor
from celer import GroupLassoCV

X = np.random.randn(50, 20)
Y = np.random.randn(50, 8)
model = MultiOutputRegressor(GroupLassoCV(groups=10), n_jobs=-1)
model.fit(X, Y)
```
```pytb
RuntimeError                              Traceback (most recent call last)
<ipython-input-2-4d37de978f75> in <module>
      7 
      8 model = MultiOutputRegressor(GroupLassoCV(groups=10), n_jobs=-1)
----> 9 model.fit(X, Y)

~/gbox/work/github/scikit-learn/sklearn/multioutput.py in fit(self, X, y, sample_weight, **fit_params)
    180                 self.estimator, X, y[:, i], sample_weight,
    181                 **fit_params_validated)
--> 182             for i in range(y.shape[1]))
    183         return self
    184 

~/gbox/work/github/joblib/joblib/parallel.py in __call__(self, iterable)
   1040 
   1041             with self._backend.retrieval_context():
-> 1042                 self.retrieve()
   1043             # Make sure that we get a last message telling us we are done
   1044             elapsed_time = time.time() - self._start_time

~/gbox/work/github/joblib/joblib/parallel.py in retrieve(self)
    919             try:
    920                 if getattr(self._backend, 'supports_timeout', False):
--> 921                     self._output.extend(job.get(timeout=self.timeout))
    922                 else:
    923                     self._output.extend(job.get())

~/gbox/work/github/joblib/joblib/_parallel_backends.py in wrap_future_result(future, timeout)
    540         AsyncResults.get from multiprocessing."""
    541         try:
--> 542             return future.result(timeout=timeout)
    543         except CfTimeoutError as e:
    544             raise TimeoutError from e

~/miniconda3/envs/py37/lib/python3.7/concurrent/futures/_base.py in result(self, timeout)
    430                 raise CancelledError()
    431             elif self._state == FINISHED:
--> 432                 return self.__get_result()
    433             else:
    434                 raise TimeoutError()

~/miniconda3/envs/py37/lib/python3.7/concurrent/futures/_base.py in __get_result(self)
    382     def __get_result(self):
    383         if self._exception:
--> 384             raise self._exception
    385         else:
    386             return self._result

RuntimeError: Cannot clone object GroupLassoCV(groups=10), as the constructor either does not set or modifies parameter precompute
```