### PR TITLE
FIX: screening prevents MTL for converging

### DIFF
--- a/celer/multitask_fast.pyx
+++ b/celer/multitask_fast.pyx
@@ -83,8 +83,9 @@ cdef void set_prios_mtl(
         nrm = fnrm2(&n_tasks, &Xj_theta[0], &inc)
         prios[j] = (1. - nrm) / norms_X_col[j]
         if prios[j] > radius:
-            screened[j] = True
-            n_screened[0] += 1
+            pass
+            # screened[j] = True
+            # n_screened[0] += 1
 
 
 @cython.boundscheck(False)


### PR DESCRIPTION
Attempt at understanding #201 

@PABannier thanks, from what I saw it's a screening issue (a feature is removed from the problem while it shouldn't, thus preventing convergence) 

A quick fix is to disable screening as I have done here. It fixes the example you sent me. I'd rather not merge because maybe it makes the solver slower.