### PR TITLE
FIX primal computations with infinite weights

### DIFF
--- a/celer/cython_utils.pyx
+++ b/celer/cython_utils.pyx
@@ -129,7 +129,9 @@ cdef floating primal_logreg(
     for i in range(n_samples):
         p_obj += log_1pexp(- y[i] * Xw[i])
     for j in range(n_features):
-        p_obj += alpha * weights[j] * fabs(w[j])
+        # avoid nan when weights[j] is INFINITY
+        if w[j]:
+            p_obj += alpha * weights[j] * fabs(w[j])
     return p_obj
 
 
@@ -147,7 +149,9 @@ cdef floating primal_lasso(
     cdef floating p_obj = 0.
     p_obj = fdot(&n_samples, &R[0], &inc, &R[0], &inc) / (2. * n_samples)
     for j in range(n_features):
-        p_obj += alpha * weights[j] * fabs(w[j])
+        # avoid nan when weights[j] is INFINITY
+        if w[j]:
+            p_obj += alpha * weights[j] * fabs(w[j])
     return p_obj
 
 

--- a/celer/group_fast.pyx
+++ b/celer/group_fast.pyx
@@ -33,12 +33,12 @@ cpdef floating primal_grplasso(
     cdef floating p_obj = fnrm2(&n_samples, &R[0], &inc) ** 2 / (2 * n_samples)
 
     for g in range(n_groups):
-        nrm = 0.
-
-        for k in range(grp_ptr[g], grp_ptr[g + 1]):
-            j = grp_indices[k]
-            nrm += w[j] ** 2
-        p_obj += alpha * sqrt(nrm) * weights[g]
+        if weights[g] != INFINITY:
+            nrm = 0.
+            for k in range(grp_ptr[g], grp_ptr[g + 1]):
+                j = grp_indices[k]
+                nrm += w[j] ** 2
+                p_obj += alpha * sqrt(nrm) * weights[g]
 
     return p_obj
 


### PR DESCRIPTION
@sehoff this explains why your case 3.1 was slow. use Lasso(verbose=1) or verbose=2 to get more info about the solver progress; here the primal objective was at first iteration, hence it was just running until the max number of iterations and epochs, so a very long time.

@Badr-MOUFAD have a look at this, when this is merged can you add a unit test testing this case for Lasso, LogisticRegression and GroupLasso ?


Basic script to reproduce the issue on main:
```python
import numpy as np
from celer import Lasso, GroupLasso

np.random.seed(1)
X = np.random.randn(50, 60)
y = np.random.randn(50)

weights = np.ones(60)
weights[30:] = np.inf
alpha_max = np.max(np.abs(X.T @ y) / weights) / len(y)
clf = Lasso(alpha=alpha_max / 10, weights=weights,
            max_iter=1, max_epochs=20, verbose=2).fit(X, y)
```