### PR TITLE
API - expose acceleration params

### DIFF
--- a/celer/dropin_sklearn.py
+++ b/celer/dropin_sklearn.py
@@ -1046,6 +1046,9 @@ class GroupLasso(Lasso_sklearn):
         When set to True, reuse the solution of the previous call to fit as
         initialization, otherwise, just erase the previous solution.
 
+    use_acc: bool, optional (default=True)
+        Whether to extrapolation to accelerate the solver.
+
     Attributes
     ----------
     coef_ : array, shape (n_features,)
@@ -1091,7 +1094,7 @@ class GroupLasso(Lasso_sklearn):
 
     def __init__(self, groups=1, alpha=1., max_iter=100,
                  max_epochs=50000, p0=10, verbose=0, tol=1e-4, prune=True,
-                 fit_intercept=True, weights=None, warm_start=False):
+                 fit_intercept=True, weights=None, warm_start=False, use_acc=True):
         super(GroupLasso, self).__init__(
             alpha=alpha, tol=tol, max_iter=max_iter,
             fit_intercept=fit_intercept,
@@ -1102,6 +1105,7 @@ class GroupLasso(Lasso_sklearn):
         self.p0 = p0
         self.prune = prune
         self.weights = weights
+        self.use_acc = use_acc
 
     def path(self, X, y, alphas, coef_init=None, return_n_iter=True,
              **kwargs):
@@ -1112,7 +1116,7 @@ class GroupLasso(Lasso_sklearn):
             return_n_iter=return_n_iter, max_epochs=self.max_epochs,
             p0=self.p0, verbose=self.verbose, tol=self.tol, prune=self.prune,
             weights=self.weights, X_scale=kwargs.get('X_scale', None),
-            X_offset=kwargs.get('X_offset', None))
+            X_offset=kwargs.get('X_offset', None),  use_acc=self.use_acc)
 
         return results
 

--- a/celer/homotopy.py
+++ b/celer/homotopy.py
@@ -26,7 +26,7 @@ def celer_path(X, y, pb, eps=1e-3, n_alphas=100, alphas=None, l1_ratio=1.0,
                coef_init=None, max_iter=20, max_epochs=50000,
                p0=10, verbose=0, tol=1e-6, prune=0, weights=None,
                groups=None, return_thetas=False, use_PN=False, X_offset=None,
-               X_scale=None, return_n_iter=False, positive=False):
+               X_scale=None, return_n_iter=False, positive=False, use_acc=True):
     r"""Compute optimization path with Celer as inner solver.
 
     With `n = len(y)` and `p = len(w)` the number of samples and features,
@@ -139,6 +139,9 @@ def celer_path(X, y, pb, eps=1e-3, n_alphas=100, alphas=None, l1_ratio=1.0,
 
     positive : bool, optional (default=False)
         If True and pb == "lasso", forces the coefficients to be positive.
+
+    use_acc: bool, optional (default=True)
+        Whether to extrapolation to accelerate the solver.
 
     Returns
     -------
@@ -311,7 +314,7 @@ def celer_path(X, y, pb, eps=1e-3, n_alphas=100, alphas=None, l1_ratio=1.0,
                 is_sparse, LASSO, X_dense, grp_indices, grp_ptr, X_data,
                 X_indices, X_indptr, X_sparse_scaling, y, alpha, w, Xw, theta,
                 norms_X_grp, tol, weights, max_iter, max_epochs, p0=p0,
-                prune=prune, verbose=verbose)
+                prune=prune, verbose=verbose, use_accel=use_acc)
         # TODO handle case of enet
         elif pb == LASSO or (pb == LOGREG and not use_PN):
             sol = celer(
@@ -319,7 +322,7 @@ def celer_path(X, y, pb, eps=1e-3, n_alphas=100, alphas=None, l1_ratio=1.0,
                 X_dense, X_data, X_indices, X_indptr, X_sparse_scaling, y,
                 alpha, l1_ratio, w, Xw, theta, norms_X_col, weights,
                 max_iter=max_iter, max_epochs=max_epochs,
-                p0=p0, verbose=verbose, use_accel=1, tol=tol, prune=prune,
+                p0=p0, verbose=verbose, use_accel=use_acc, tol=tol, prune=prune,
                 positive=positive)
         else:  # pb == LOGREG and use_PN
             sol = newton_celer(


### PR DESCRIPTION
This aims to expose acceleration params to make benchmarking with other solvers much easier. 

It will proceed as follows

- [ ] expose ``use_acc`` 
- [ ] expose ``K``