### PR TITLE
FIX - Add ``utf-8`` encoding option when reading ``README``

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if version is None:
 
 DISTNAME = 'celer'
 DESCRIPTION = descr
-with open('README.md', 'r') as f:
+with open('README.md', 'r', encoding='utf-8') as f:
     LONG_DESCRIPTION = f.read()
 MAINTAINER = 'Mathurin Massias'
 MAINTAINER_EMAIL = 'mathurin.massias@gmail.com'


### PR DESCRIPTION
This addresses the problem of incorrectly reading some characters in README.
(cf. https://test.pypi.org/project/celer/0.7.2.dev3/)