### PR TITLE
MAINT: drop deprecated plot argument

### DIFF
--- a/examples/plot_group_lasso.py
+++ b/examples/plot_group_lasso.py
@@ -67,8 +67,7 @@ labels = ["LassoCV-estimated regression coefficients",
 colors = [u'#ff7f0e', u'#2ca02c']
 
 for w, label, color in zip([lasso.coef_, group_lasso.coef_], labels, colors):
-    m, s, _ = plt.stem(np.where(w)[0], w[w != 0], label=label,
-                       markerfmt='x', use_line_collection=True)
+    m, s, _ = plt.stem(np.where(w)[0], w[w != 0], label=label, markerfmt='x')
     plt.setp([m, s], color=color)
 plt.xlabel("feature index")
 plt.legend(fontsize=12)

--- a/examples/plot_group_lasso.py
+++ b/examples/plot_group_lasso.py
@@ -60,8 +60,7 @@ lasso = LassoCV().fit(X, y)
 
 fig = plt.figure(figsize=(8, 3), constrained_layout=True)
 m, s, _ = plt.stem(np.where(w_true)[0], w_true[w_true != 0],
-                   label=r"true regression coefficients",
-                   use_line_collection=True)
+                   label=r"true regression coefficients")
 labels = ["LassoCV-estimated regression coefficients",
           "GroupLassoCV-estimated regression coefficients"]
 colors = [u'#ff7f0e', u'#2ca02c']


### PR DESCRIPTION
`use_line_collection` is deprecated since 3.6 and was removed in 3.8, see https://matplotlib.org/3.7.3/api/_as_gen/matplotlib.pyplot.stem.html