### PR TITLE
Drop numpy.math imports due to deprecation in recent versions of Cython.

### DIFF
--- a/celer/cython_utils.pyx
+++ b/celer/cython_utils.pyx
@@ -10,8 +10,7 @@ cimport numpy as np
 from scipy.linalg.cython_blas cimport ddot, dasum, daxpy, dnrm2, dcopy, dscal
 from scipy.linalg.cython_blas cimport sdot, sasum, saxpy, snrm2, scopy, sscal
 from scipy.linalg.cython_lapack cimport sposv, dposv
-from libc.math cimport fabs, log, exp, sqrt
-from numpy.math cimport INFINITY
+from libc.math cimport fabs, log, exp, sqrt, INFINITY
 from cython cimport floating
 
 

--- a/celer/group_fast.pyx
+++ b/celer/group_fast.pyx
@@ -7,9 +7,8 @@ import numpy as np
 cimport numpy as np
 import warnings
 
-from numpy.math cimport INFINITY
 from cython cimport floating
-from libc.math cimport fabs, sqrt
+from libc.math cimport fabs, sqrt, INFINITY
 from sklearn.exceptions import ConvergenceWarning
 
 from .cython_utils cimport (fdot, fasum, faxpy, fnrm2, fcopy, fscal, dual,

--- a/celer/multitask_fast.pyx
+++ b/celer/multitask_fast.pyx
@@ -5,8 +5,7 @@ cimport numpy as np
 import numpy as np
 import warnings
 from cython cimport floating
-from libc.math cimport fabs, sqrt
-from numpy.math cimport INFINITY
+from libc.math cimport fabs, sqrt, INFINITY
 from sklearn.exceptions import ConvergenceWarning
 
 from .cython_utils cimport fscal, fcopy, fnrm2, fdot, faxpy


### PR DESCRIPTION
Addresses #303. We simply replace `numpy.math` with `libc.math`.